### PR TITLE
fix: Use concurrent queue and dictionary to avoid race conditions.

### DIFF
--- a/ReGoap/Core/ReGoapState.cs
+++ b/ReGoap/Core/ReGoapState.cs
@@ -1,21 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace ReGoap.Core
 {
     public class ReGoapState<T, W>
     {
         // can change to object
-        private Dictionary<T, W> values;
-        private readonly Dictionary<T, W> bufferA;
-        private readonly Dictionary<T, W> bufferB;
+        private ConcurrentDictionary<T, W> values;
+        private readonly ConcurrentDictionary<T, W> bufferA;
+        private readonly ConcurrentDictionary<T, W> bufferB;
 
         public static int DefaultSize = 20;
 
         private ReGoapState()
         {
-            bufferA = new Dictionary<T, W>(DefaultSize);
-            bufferB = new Dictionary<T, W>(DefaultSize);
+            int concurrencyLevel = 5; // No idea.
+            bufferA = new ConcurrentDictionary<T, W>(concurrencyLevel, DefaultSize);
+            bufferB = new ConcurrentDictionary<T, W>(concurrencyLevel, DefaultSize);
             values = bufferA;
         }
 
@@ -258,16 +260,17 @@ namespace ReGoap.Core
 
         public void Remove(T key)
         {
-            lock (values)
-            {
-                values.Remove(key);
-            }
+            values.TryRemove(key, out _);
         }
 
-        public Dictionary<T, W> GetValues()
+        public ConcurrentDictionary<T, W> GetValues()
         {
             lock (values)
                 return values;
+        }
+
+        public bool TryGetValue(T key, out W value) {
+            return values.TryGetValue(key, out value);
         }
 
         public bool HasKey(T key)

--- a/ReGoap/Unity/FSMExample/Actions/CraftRecipeAction.cs
+++ b/ReGoap/Unity/FSMExample/Actions/CraftRecipeAction.cs
@@ -61,8 +61,8 @@ namespace ReGoap.Unity.FSMExample.Actions
 
         public override ReGoapState<string, object> GetPreconditions(GoapActionStackData<string, object> stackData)
         {
-            if (stackData.settings.HasKey("workstationPosition"))
-                preconditions.Set("isAtPosition", stackData.settings.Get("workstationPosition"));
+            if (stackData.settings.TryGetValue("workstationPosition", out var workstationPosition))
+                preconditions.Set("isAtPosition", workstationPosition);
             return preconditions;
         }
 

--- a/ReGoap/Unity/FSMExample/Actions/GatherResourceAction.cs
+++ b/ReGoap/Unity/FSMExample/Actions/GatherResourceAction.cs
@@ -47,9 +47,10 @@ namespace ReGoap.Unity.FSMExample.Actions
         public override ReGoapState<string, object> GetPreconditions(GoapActionStackData<string, object> stackData)
         {
             preconditions.Clear();
-            if (stackData.settings.HasKey("resource"))
+            if (stackData.settings.HasKey("resource")
+                && stackData.settings.TryGetValue("resourcePosition", out var resourcePosition))
             {
-                preconditions.Set("isAtPosition", stackData.settings.Get("resourcePosition"));
+                preconditions.Set("isAtPosition", resourcePosition);
             }
             return preconditions;
         }
@@ -57,9 +58,11 @@ namespace ReGoap.Unity.FSMExample.Actions
         public override ReGoapState<string, object> GetEffects(GoapActionStackData<string, object> stackData)
         {
             effects.Clear();
-            if (stackData.settings.HasKey("resource"))
+            if (stackData.settings.TryGetValue("resource", out var obj))
             {
-                effects.Set("hasResource" + ((IResource)stackData.settings.Get("resource")).GetName(), true);
+                var resource = (IResource) obj;
+                if (resource != null)
+                    effects.Set("hasResource" + resource.GetName(), true);
             }
             return effects;
         }
@@ -85,7 +88,10 @@ namespace ReGoap.Unity.FSMExample.Actions
                     }
                     else
                     {
-                        var score = stackData.currentState.HasKey("isAtPosition") ? (wantedResource.position - (Vector3)stackData.currentState.Get("isAtPosition")).magnitude : 0.0f;
+                        var score = stackData.currentState.TryGetValue("isAtPosition",
+                                                                       out object isAtPosition)
+                            ? (wantedResource.position - (Vector3)isAtPosition).magnitude
+                            : 0.0f;
                         score += ReservedCostMultiplier * wantedResource.resource.GetReserveCount();
                         score += ResourcesCostMultiplier * (MaxResourcesCount - wantedResource.resource.GetCapacity());
                         if (score < bestScore)

--- a/ReGoap/Unity/FSMExample/Actions/GenericGoToAction.cs
+++ b/ReGoap/Unity/FSMExample/Actions/GenericGoToAction.cs
@@ -30,8 +30,8 @@ namespace ReGoap.Unity.FSMExample.Actions
         {
             base.Run(previous, next, settings, goalState, done, fail);
             
-            if (settings.HasKey("objectivePosition"))
-                smsGoto.GoTo((Vector3) settings.Get("objectivePosition"), OnDoneMovement, OnFailureMovement);
+            if (settings.TryGetValue("objectivePosition", out var v))
+                smsGoto.GoTo((Vector3) v, OnDoneMovement, OnFailureMovement);
             else
                 failCallback(this);
         }
@@ -43,9 +43,9 @@ namespace ReGoap.Unity.FSMExample.Actions
 
         public override ReGoapState<string, object> GetEffects(GoapActionStackData<string, object> stackData)
         {
-            if (stackData.settings.HasKey("objectivePosition"))
+            if (stackData.settings.TryGetValue("objectivePosition", out var objectivePosition))
             {
-                effects.Set("isAtPosition", stackData.settings.Get("objectivePosition"));
+                effects.Set("isAtPosition", objectivePosition);
                 if (stackData.settings.HasKey("reconcilePosition"))
                     effects.Set("reconcilePosition", true);
             }
@@ -58,9 +58,9 @@ namespace ReGoap.Unity.FSMExample.Actions
 
         public override List<ReGoapState<string, object>> GetSettings(GoapActionStackData<string, object> stackData)
         {
-            if (stackData.goalState.HasKey("isAtPosition"))
+            if (stackData.goalState.TryGetValue("isAtPosition", out var isAtPosition))
             {
-                settings.Set("objectivePosition", stackData.goalState.Get("isAtPosition"));
+                settings.Set("objectivePosition", isAtPosition);
                 return base.GetSettings(stackData);
             }
             else if (stackData.goalState.HasKey("reconcilePosition") && stackData.goalState.Count == 1)
@@ -76,9 +76,11 @@ namespace ReGoap.Unity.FSMExample.Actions
         public override float GetCost(GoapActionStackData<string, object> stackData)
         {
             var distance = 0.0f;
-            if (stackData.settings.HasKey("objectivePosition") && stackData.currentState.HasKey("isAtPosition"))
+            if (stackData.settings.TryGetValue("objectivePosition", out object objectivePosition)
+                && stackData.currentState.TryGetValue("isAtPosition", out object isAtPosition))
             {
-                distance = ((Vector3)stackData.settings.Get("objectivePosition") - (Vector3)stackData.currentState.Get("isAtPosition")).magnitude;
+                if (objectivePosition is Vector3 p && isAtPosition is Vector3 r)
+                    distance = (p - r).magnitude;
             }
             return base.GetCost(stackData) + Cost + distance;
         }


### PR DESCRIPTION
With Unity2019.1.0a13 the example scene had failures with WorksQueue.Dequeue()
initially.  Presumably this is because the WorksQueue.Count test and Dequeue()
happen at different times.  To fix this, I switched WorksQueue to a
ConcurrentQueue and use TryDequeue() which dequeues atomically if there is an
item available and returns true; otherwise, it returns false.

After that was fixed, a new error popped up when the trees ran out. This
appeared to be caused by a race condition between the test for HasKey and Get.
To fix this, I switched the dictionaries in ReGoapState to ConcurrentDictionary
classes. And I removed Get() in favor of TryGetValue() which avoids that race
condition.

The example scene works.  All unit tests pass.

I hope these bugs mean that Unity is using more threads than it was before.